### PR TITLE
Edit Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
   - "3.4"
+  - "3.6"
 sudo: true
 
 before_install: "sudo apt-get install python-dev libevent-dev"


### PR DESCRIPTION
Edit Travis by removing python 2 and python 3.3 test builds. Tests for Python 3.4 and 3.6 are passing and functional.